### PR TITLE
Bugfix with create_default_virtualserver

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,7 @@
 ---
 # handlers file for teamspeak
-
 - name: Reload systemd
-  command: systemctl daemon-reload
+  systemd: daemon-reload=yes
 
 - name: Restart TeamSpeak 3 Server
   service:

--- a/templates/ts3server.ini.j2
+++ b/templates/ts3server.ini.j2
@@ -5,9 +5,8 @@ filetransfer_ip={{ teamspeak_network.filetransfer.ip }}
 query_port={{ teamspeak_network.query.port }}
 query_ip={{ teamspeak_network.query.ip }}
 
-{% if teamspeak_create_default_virtualserver %}
-create_default_virtualserver=1
-{% endif %}
+create_default_virtualserver={% 1 if teamspeak_create_default_virtualserver else 0 %}
+
 {% if teamspeak_use_license and teamspeak_licensepath is not none %}
 licensepath={{ teamspeak_licensepath }}/
 {% endif %}

--- a/templates/ts3server.ini.j2
+++ b/templates/ts3server.ini.j2
@@ -5,7 +5,7 @@ filetransfer_ip={{ teamspeak_network.filetransfer.ip }}
 query_port={{ teamspeak_network.query.port }}
 query_ip={{ teamspeak_network.query.ip }}
 
-create_default_virtualserver={% 1 if teamspeak_create_default_virtualserver else 0 %}
+create_default_virtualserver={{ '1' if teamspeak_create_default_virtualserver else '0' }}
 
 {% if teamspeak_use_license and teamspeak_licensepath is not none %}
 licensepath={{ teamspeak_licensepath }}/


### PR DESCRIPTION
Fixed: create_default_virtualserver is default true. So it always create default server
Small update to handlers to not execute systemctl daemon-reload direct with command, but with systemctl module.