### PR TITLE
Fix issue 7

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -10,3 +10,7 @@
     group: "{{ teamspeak.user }}"
   notify:
     - Restart TeamSpeak 3 Server
+
+- name: "grep ServerAdmin Password"
+  shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi \'password= "(.*)"\' | cut -d\" -f2 | tail -n1'
+  register: __ts3_serveradmin_password

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -11,9 +11,18 @@
   notify:
     - Restart TeamSpeak 3 Server
 
-- name: "grep ServerAdmin Password"
+- name: "Configuration : Fetch ServerAdmin Password"
   shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi \'password= "(.*)"\' | cut -d\" -f2 | tail -n1'
   register: __ts3_serveradmin_password
-- name: "Fetch default server Privilege token"
-  shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi 'token=(.*)' | cut -d= -f2 | tail -n1'
-  register: __ts3_serveradmin_password
+
+- debug: 
+    msg: "ServerAdmin Password: {{ __ts3_serveradmin_password.stdout }}"
+
+- block:
+  - name: "Configuration : Fetch default server privilege token"
+    shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi \'token=(.*)\' | cut -d= -f2 | tail -n1'
+    register: __ts3_default_priv_token
+  - debug: 
+      msg: "Default virtualserver privilege token: {{ __ts3_default_priv_token.stdout }}"
+- when: teamspeak_create_default_virtualserver
+

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -14,3 +14,6 @@
 - name: "grep ServerAdmin Password"
   shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi \'password= "(.*)"\' | cut -d\" -f2 | tail -n1'
   register: __ts3_serveradmin_password
+- name: "Fetch default server Privilege token"
+  shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi 'token=(.*)' | cut -d= -f2 | tail -n1'
+  register: __ts3_serveradmin_password

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -11,12 +11,26 @@
   notify:
     - Restart TeamSpeak 3 Server
 
+- name: "Configuration : Start TeamSpeak 3 Server"
+  service:
+    name: teamspeak3-server
+    state: started
+  register: __ts3_service_started
+
+- name: "Configuration : Wait until TeamSpeak 3 ServerQuery is open"
+  wait_for:
+    port: "{{ teamspeak_network.query.port }}"
+    timeout: 10 
+  when: __ts3_service_started.changed
+
 - name: "Configuration : Fetch ServerAdmin Password"
   shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi "password= \"(.*)\"" | cut -d\" -f2 | tail -n1'
   register: __ts3_serveradmin_password
+  when: __ts3_service_started.changed
 
 - debug: 
     msg: "ServerAdmin Password: {{ __ts3_serveradmin_password.stdout }}"
+  when: __ts3_service_started.changed
 
 - block:
   - name: "Configuration : Fetch default server privilege token"
@@ -24,5 +38,5 @@
     register: __ts3_default_priv_token
   - debug: 
       msg: "Default virtualserver privilege token: {{ __ts3_default_priv_token.stdout }}"
-  when: teamspeak_create_default_virtualserver
+  when: teamspeak_create_default_virtualserver and __ts3_service_started.changed
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,7 +12,7 @@
     - Restart TeamSpeak 3 Server
 
 - name: "Configuration : Fetch ServerAdmin Password"
-  shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi \'password= "(.*)"\' | cut -d\" -f2 | tail -n1'
+  shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi "password= \"(.*)\"" | cut -d\" -f2 | tail -n1'
   register: __ts3_serveradmin_password
 
 - debug: 
@@ -20,9 +20,9 @@
 
 - block:
   - name: "Configuration : Fetch default server privilege token"
-    shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi \'token=(.*)\' | cut -d= -f2 | tail -n1'
+    shell: 'journalctl -u teamspeak3-server.service --since today | grep -oEi "token=(.*)" | cut -d= -f2 | tail -n1'
     register: __ts3_default_priv_token
   - debug: 
       msg: "Default virtualserver privilege token: {{ __ts3_default_priv_token.stdout }}"
-- when: teamspeak_create_default_virtualserver
+  when: teamspeak_create_default_virtualserver
 


### PR DESCRIPTION
This added a debug message to display ServerQuery Admin password and the default virtualserver token.
When teamspeak_create_default_virtualserver is false it will skip debug for the privilege token.

The teamspeak server needed to be started to display the password and token. With module wait_for it check if the query port is open. That is a way to check if the database is created.

Greetz,
Egbert