### PR TITLE
Fix error with userdata.stat.exists

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,7 +35,7 @@
 
 # If user data has been found, this is an upgrade situation.
 - include: ts3update.yml
-  when: userdata.stat.exists is defined and userdata.stat.exists == True
+  when: userdata.stat is defined and userdata.stat.exists == True
 
 # Created a new directory? Extract the files into it. Overwrites existing.
 - name: "Install : Extract TeamSpeak {{ teamspeak.version }} Server files"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,4 +62,4 @@
 # Display Teamspeak 3 Server Token and Password if this is a new installation
 # (a new installation has no userdata, and this is checked for in install.yml)
 - include: display.yml
-  when: userdata.stat.exists is defined and userdata.stat.exists == False
+  when: userdata.stat is defined and userdata.stat.exists == False


### PR DESCRIPTION
Starting with v2.3.0.0-0.1.rc1, ansible treats undefined variables
slightly differently, see ansible/ansible@81aa12eb.

Checking for variable.stat instead of variable.stat.exists fixes this
problem.