### PR TITLE
Add IPv6 "::" address to ts3server.ini

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,13 +21,13 @@ teamspeak_licensepath:
 teamspeak_network:
   voice:
     default_port: 9987
-    ip: 0.0.0.0
+    ip: "0.0.0.0, ::"
   filetransfer:
     port: 30033 
-    ip: 0.0.0.0
+    ip: "0.0.0.0, ::"
   query:
     port: 10011
-    ip: 0.0.0.0
+    ip: "0.0.0.0, ::"
 
 teamspeak_create_default_virtualserver: yes
 teamspeak_machine_id:


### PR DESCRIPTION
With the default configuration the Teamspeak server is only reachable over IPv4.

While this is only a default configuration I think it would be helpful to add the IPv6 "any" address to the default configuration because on most servers and Linux systems ipv6 nowadays is enabled by default.