### PR TITLE
Added query ssh configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,4 +35,4 @@ teamspeak_network:
 teamspeak_create_default_virtualserver: yes
 teamspeak_machine_id:
 
-teamspeak_query_ssh_enabled: no
+teamspeak_query_ssh_enabled: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,11 @@ teamspeak_network:
   query:
     port: 10011
     ip: 0.0.0.0
+  query_ssh:
+    port: 10022
+    ip: "0.0.0.0, ::"
 
 teamspeak_create_default_virtualserver: yes
 teamspeak_machine_id:
+
+teamspeak_query_ssh_enabled: no

--- a/templates/ts3server.ini.j2
+++ b/templates/ts3server.ini.j2
@@ -5,6 +5,8 @@ filetransfer_ip={{ teamspeak_network.filetransfer.ip }}
 query_port={{ teamspeak_network.query.port }}
 query_ip={{ teamspeak_network.query.ip }}
 
+query_protocols=raw{% if teamspeak_query_ssh_enabled %}, ssh{% endif %}
+
 create_default_virtualserver={{ '1' if teamspeak_create_default_virtualserver else '0' }}
 
 {% if teamspeak_use_license and teamspeak_licensepath is not none %}
@@ -12,4 +14,10 @@ licensepath={{ teamspeak_licensepath }}/
 {% endif %}
 {% if teamspeak_machine_id is not none %}
 machine_id={{ teamspeak_machine_id }}
+{% endif %}
+
+{% if teamspeak_query_ssh_enabled %}
+query_ssh_ip={{ teamspeak_network.query_ssh.ip }}
+query_ssh_port={{ teamspeak_network.query_ssh.port }}
+query_ssh_rsa_host_key=ssh_host_rsa_key
 {% endif %}


### PR DESCRIPTION
With TeamSpeak Server Version 3.3.0 a new query option was added to TeamSpeak.
By default queries over ssh are enabled. But in this role they aren't configurable.

So I've added a simple configuration for queries over ssh and the possibility to disable them.