### PR TITLE
switch to systemd module for reloading systemd

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,8 @@
 # handlers file for teamspeak
 
 - name: Reload systemd
-  command: systemctl daemon-reload
+  systemd:
+    daemon_reload: yes
 
 - name: Restart TeamSpeak 3 Server
   service:


### PR DESCRIPTION
In #5 the systemd daemon reload with the command module was added.
With ansible 2.2 the new systemd module is aviable and should be used here 👍 

There is no real issue with the normal command right here, but in my opinion a normal module should always be used instead of a command or shell module.