### PR TITLE
Changed license permission from read to read/write

### DIFF
--- a/tasks/install_license.yml
+++ b/tasks/install_license.yml
@@ -13,6 +13,6 @@
     dest: "{{ teamspeak_licensepath if teamspeak_licensepath is not none else ts3server_dir }}/licensekey.dat"
     owner: "{{ teamspeak.user }}"
     group: "{{ teamspeak.user }}"
-    mode: 0400
+    mode: 0600
   notify:
     - Restart TeamSpeak 3 Server


### PR DESCRIPTION
The Teamspeak Server needs to have write access to the license file. I'm currently using a NPL and my Teamspeak Server wanted to write to the license file.
Because of the read only permissions the server wasn't able to do it and stopped with the following error.

`2020-03-31 19:28:06.791160|ERROR   |Accounting    |   |Error while writing new license file, shutting down!`

With this change the permission will be changed to -rw-------.